### PR TITLE
Fix NvimTmuxNavigatePrevious function call if not in tmux

### DIFF
--- a/lua/nvim-tmux-navigation/init.lua
+++ b/lua/nvim-tmux-navigation/init.lua
@@ -94,7 +94,7 @@ else
     function M.NvimTmuxNavigateDown() vim_navigate('j') end
     function M.NvimTmuxNavigateUp() vim_navigate('k') end
     function M.NvimTmuxNavigateRight() vim_navigate('l') end
-    function M.NvimTmuxNavigatePrevious() VimNavigate('p') end
+    function M.NvimTmuxNavigatePrevious() vim_navigate('p') end
 end
 
 return M


### PR DESCRIPTION
Hey, it looks like there is a typo in the `NvimTmuxNavigatePrevious` function.