### PR TITLE
Add navigate next method

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The default keybinds are (in tmux):
 - `Ctrl + k`: move up
 - `Ctrl + l`: move right
 - `Ctrl + \`: move to previous pane
+- `Ctrl + Space` move to the next pane
 
 However, this means that you lose access to the "clear screen" terminal feature,
 activated by `<Ctrl-l>` by default. You can either:
@@ -69,12 +70,14 @@ if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
     "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
 if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
     "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+bind-key -n 'C-Space' if-shell "$is_vim" 'send-keys C-Space' 'select-pane -t:.+'
 
 bind-key -T copy-mode-vi 'C-h' select-pane -L
 bind-key -T copy-mode-vi 'C-j' select-pane -D
 bind-key -T copy-mode-vi 'C-k' select-pane -U
 bind-key -T copy-mode-vi 'C-l' select-pane -R
 bind-key -T copy-mode-vi 'C-\' select-pane -l
+bind-key -T copy-mode-vi 'C-Space' select-pane -t:.+
 ```
 
 ### Neovim
@@ -92,6 +95,7 @@ nnoremap <silent> <C-j> :lua require'nvim-tmux-navigation'.NvimTmuxNavigateDown(
 nnoremap <silent> <C-k> :lua require'nvim-tmux-navigation'.NvimTmuxNavigateUp()<cr>
 nnoremap <silent> <C-l> :lua require'nvim-tmux-navigation'.NvimTmuxNavigateRight()<cr>
 nnoremap <silent> <C-\> :lua require'nvim-tmux-navigation'.NvimTmuxNavigatePrevious()<cr>
+nnoremap <silent> <C-Space> :lua require'nvim-tmux-navigation'.NvimTmuxNavigateNext()<cr>
 ```
 
 There are additional settings for the plugin, for example disable navigation
@@ -119,6 +123,7 @@ use { 'alexghergh/nvim-tmux-navigation', config = function()
         vim.api.nvim_set_keymap('n', "<C-k>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigateUp()<cr>", { noremap = true, silent = true })
         vim.api.nvim_set_keymap('n', "<C-l>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigateRight()<cr>", { noremap = true, silent = true })
         vim.api.nvim_set_keymap('n', "<C-\>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigatePrevious()<cr>", { noremap = true, silent = true })
+        vim.api.nvim_set_keymap('n', "<C-Space>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigateNext()<cr>", { noremap = true, silent = true })
     end
 }
 ```
@@ -135,6 +140,7 @@ use { 'alexghergh/nvim-tmux-navigation', config = function()
                 up = "<C-k>",
                 right = "<C-l>",
                 previous = "<C-\>",
+                next = "<C-Space>",
             }
         }
     end

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The default keybinds are (in tmux):
 - `Ctrl + j`: move down
 - `Ctrl + k`: move up
 - `Ctrl + l`: move right
-- `Ctrl + \`: move to previous pane
-- `Ctrl + Space` move to the next pane
+- `Ctrl + \`: move to the last (previously active) pane
+- `Ctrl + Space` move to the next pane (by pane number)
 
 However, this means that you lose access to the "clear screen" terminal feature,
 activated by `<Ctrl-l>` by default. You can either:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ use { 'alexghergh/nvim-tmux-navigation', config = function()
         vim.api.nvim_set_keymap('n', "<C-j>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigateDown()<cr>", { noremap = true, silent = true })
         vim.api.nvim_set_keymap('n', "<C-k>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigateUp()<cr>", { noremap = true, silent = true })
         vim.api.nvim_set_keymap('n', "<C-l>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigateRight()<cr>", { noremap = true, silent = true })
-        vim.api.nvim_set_keymap('n', "<C-\>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigatePrevious()<cr>", { noremap = true, silent = true })
+        vim.api.nvim_set_keymap('n', "<C-\\>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigatePrevious()<cr>", { noremap = true, silent = true })
         vim.api.nvim_set_keymap('n', "<C-Space>", ":lua require'nvim-tmux-navigation'.NvimTmuxNavigateNext()<cr>", { noremap = true, silent = true })
     end
 }
@@ -139,7 +139,7 @@ use { 'alexghergh/nvim-tmux-navigation', config = function()
                 down = "<C-j>",
                 up = "<C-k>",
                 right = "<C-l>",
-                previous = "<C-\>",
+                previous = "<C-\\>",
                 next = "<C-Space>",
             }
         }

--- a/lua/nvim-tmux-navigation/init.lua
+++ b/lua/nvim-tmux-navigation/init.lua
@@ -94,7 +94,7 @@ else
     function M.NvimTmuxNavigateDown() vim_navigate('j') end
     function M.NvimTmuxNavigateUp() vim_navigate('k') end
     function M.NvimTmuxNavigateRight() vim_navigate('l') end
-    function M.NvimTmuxNavigatePrevious() VimNavigate('p') end
+    function M.NvimTmuxNavigatePrevious() vim_navigate('p') end
 end
 
 return M

--- a/lua/nvim-tmux-navigation/init.lua
+++ b/lua/nvim-tmux-navigation/init.lua
@@ -9,7 +9,9 @@ local config = {
 }
 
 local function vim_navigate(direction)
-    if pcall(vim.cmd, 'wincmd ' .. direction) then
+    if direction == 'n' then
+        pcall(vim.cmd, 'wincmd w')
+    elseif pcall(vim.cmd, 'wincmd ' .. direction) then
         -- success
     else
         -- error, cannot wincmd from the command-line window
@@ -24,7 +26,18 @@ end
 local tmux_control = true
 
 local function tmux_navigate(direction)
-    if direction == 'p' then
+    if direction == 'n' then
+
+        local is_last_win = (vim.fn.winnr() == vim.fn.winnr('$'))
+
+        if is_last_win then
+            pcall(vim.cmd, 'wincmd t')
+            util.tmux_change_pane(direction)
+        else
+            vim_navigate(direction)
+        end
+
+    elseif direction == 'p' then
 
         -- if the last pane was a tmux pane, then we need to handle control
         -- to tmux; otherwise, just issue a last pane command in vim
@@ -34,7 +47,7 @@ local function tmux_navigate(direction)
             vim_navigate(direction)
         end
 
-    elseif direction ~= 'p' then
+    else
 
         -- save the current window number to check later whether we're in the same
         -- window after issuing a vim navigation command
@@ -88,6 +101,7 @@ if vim.env.TMUX ~= nil then
     function M.NvimTmuxNavigateUp() tmux_navigate('k') end
     function M.NvimTmuxNavigateRight() tmux_navigate('l') end
     function M.NvimTmuxNavigatePrevious() tmux_navigate('p') end
+    function M.NvimTmuxNavigateNext() tmux_navigate('n') end
 else
 -- if not in tmux, simply map to normal vim navigation
     function M.NvimTmuxNavigateLeft() vim_navigate('h') end
@@ -95,6 +109,7 @@ else
     function M.NvimTmuxNavigateUp() vim_navigate('k') end
     function M.NvimTmuxNavigateRight() vim_navigate('l') end
     function M.NvimTmuxNavigatePrevious() vim_navigate('p') end
+    function M.NvimTmuxNavigateNext() vim_navigate('n') end
 end
 
 return M

--- a/lua/nvim-tmux-navigation/tmux_util.lua
+++ b/lua/nvim-tmux-navigation/tmux_util.lua
@@ -1,6 +1,6 @@
 local util = {}
 
-local tmux_directions = { ['p'] = 'l', ['h'] = 'L', ['j'] = 'D', ['k'] = 'U', ['l'] = 'R' }
+local tmux_directions = { ['p'] = 'l', ['h'] = 'L', ['j'] = 'D', ['k'] = 'U', ['l'] = 'R', ['n'] = 't:.+' }
 
 -- send the tmux command to the server running on the socket
 -- given by the environment variable $TMUX


### PR DESCRIPTION
Hey, me again.

I have a workflow with neovim and tmux where I would like to just be able to go the next window/pane depending if I'm in neovim or in a tmux pane. I thought other people might be interested in such a workflow.

By default, I set the `Ctrl + Space` key binding as this is what I use.