### PR TITLE
Added lazy.nvim config that uses keymap based lazy-loading to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,65 @@ end
 }
 ```
 
+You can also use Lazy's lazy-loading and load the plugin on-demand only when pressing the keys.
+This will make your neovim startup time faster and also integrates with other tools like [Which Key](https://github.com/folke/which-key.nvim).
+
+```lua
+{
+  "alexghergh/nvim-tmux-navigation",
+  lazy = true,
+  keys = {
+    {
+      "<C-h>",
+      function()
+        require("nvim-tmux-navigation").NvimTmuxNavigateLeft()
+      end,
+      desc = "Move one nvim/tmux pane to the left",
+    },
+    {
+      "<C-j>",
+      function()
+        require("nvim-tmux-navigation").NvimTmuxNavigateDown()
+      end,
+      desc = "Move one nvim/tmux pane down",
+    },
+    {
+      "<C-k>",
+      function()
+        require("nvim-tmux-navigation").NvimTmuxNavigateUp()
+      end,
+      desc = "Move one nvim/tmux pane up",
+    },
+    {
+      "<C-l>",
+      function()
+        require("nvim-tmux-navigation").NvimTmuxNavigateRight()
+      end,
+      desc = "Move one nvim/tmux pane to the right",
+    },
+    {
+      "<C-\\>",
+      function()
+        require("nvim-tmux-navigation").NvimTmuxNavigateLastActive()
+      end,
+      desc = "Move to the last active nvim/tmux pane",
+    },
+    {
+      "<C-Space>",
+      function()
+        require("nvim-tmux-navigation").NvimTmuxNavigateNext()
+      end,
+      desc = "Move to the next nvim/tmux pane",
+    },
+  },
+
+  -- You don't have to include the "config" function if it's empty.
+  -- config = function()
+  --   require("nvim-tmux-navigation").setup()
+  -- end,
+}
+```
+
 ## Usage
 
 If you went through the [Configuration](#configuration), then congrats! You

--- a/README.md
+++ b/README.md
@@ -195,55 +195,49 @@ This will make your neovim startup time faster and also integrates with other to
 {
   "alexghergh/nvim-tmux-navigation",
   lazy = true,
+  cmd = {
+    "NvimTmuxNavigateLeft",
+    "NvimTmuxNavigateDown",
+    "NvimTmuxNavigateUp",
+    "NvimTmuxNavigateRight",
+    "NvimTmuxNavigateLastActive",
+    "NvimTmuxNavigateNext",
+  },
   keys = {
     {
       "<C-h>",
-      function()
-        require("nvim-tmux-navigation").NvimTmuxNavigateLeft()
-      end,
+      "<cmd>NvimTmuxNavigateLeft<cr>",
       desc = "Move one nvim/tmux pane to the left",
     },
     {
       "<C-j>",
-      function()
-        require("nvim-tmux-navigation").NvimTmuxNavigateDown()
-      end,
+      "<cmd>NvimTmuxNavigateDown<cr>",
       desc = "Move one nvim/tmux pane down",
     },
     {
       "<C-k>",
-      function()
-        require("nvim-tmux-navigation").NvimTmuxNavigateUp()
-      end,
+      "<cmd>NvimTmuxNavigateUp<cr>",
       desc = "Move one nvim/tmux pane up",
     },
     {
       "<C-l>",
-      function()
-        require("nvim-tmux-navigation").NvimTmuxNavigateRight()
-      end,
+      "<cmd>NvimTmuxNavigateRight<cr>",
       desc = "Move one nvim/tmux pane to the right",
     },
     {
       "<C-\\>",
-      function()
-        require("nvim-tmux-navigation").NvimTmuxNavigateLastActive()
-      end,
+      "<cmd>NvimTmuxNavigateLastActive<cr>",
       desc = "Move to the last active nvim/tmux pane",
     },
     {
       "<C-Space>",
-      function()
-        require("nvim-tmux-navigation").NvimTmuxNavigateNext()
-      end,
+      "<cmd>NvimTmuxNavigateNext<cr>"
       desc = "Move to the next nvim/tmux pane",
     },
   },
-
-  -- You don't have to include the "config" function if it's empty.
-  -- config = function()
-  --   require("nvim-tmux-navigation").setup()
-  -- end,
+  config = function()
+    require("nvim-tmux-navigation").setup()
+  end,
 }
 ```
 


### PR DESCRIPTION
It's a native way of Lazy.nvim to add keymaps and it has multiple advantages.

- faster load times:
if you have many plugins in neovim, lazy-loading can save you significant amount of time at startup.
- integration:
Lazy's keymaps integrate to tools like [Which Key](https://github.com/folke/which-key.nvim), which shows their descriptions