### PR TITLE
feat(nvim-tmux-navigation): add no-wrap option for tmux pane navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,14 @@ For `init.lua`, you can either map the commands manually (probably using
 it for you!
 
 There are additional settings for the plugin, for example disable navigation
-between `tmux` panes when the current pane is zoomed. To activate this option,
+between `tmux` panes when the current pane is zoomed, or disable navigation
+past the edge of the screen. To activate this option,
 just tell the plugin about it (inside the `setup` function):
 
 ```lua
 require'nvim-tmux-navigation'.setup {
-    disable_when_zoomed = true -- defaults to false
+    disable_when_zoomed = true, -- defaults to false
+    tmux_navigator_no_wrap = true -- defaults to false
 }
 ```
 
@@ -140,7 +142,8 @@ inside your `init.lua`, you can do everything at once:
     local nvim_tmux_nav = require('nvim-tmux-navigation')
 
     nvim_tmux_nav.setup {
-        disable_when_zoomed = true -- defaults to false
+        disable_when_zoomed = true, -- defaults to false
+        tmux_navigator_no_wrap = true -- defaults to false
     }
 
     vim.keymap.set('n', "<C-h>", nvim_tmux_nav.NvimTmuxNavigateLeft)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ bind-key -T copy-mode-vi 'C-l' select-pane -R
 bind-key -T copy-mode-vi 'C-\' select-pane -l
 bind-key -T copy-mode-vi 'C-Space' select-pane -t:.+
 ```
+If you're using the `no_wrap = true` option in Neovim (see Neovim configuration
+section below), you should use these alternative bindings in tmux to ensure
+consistent behavior between Neovim and tmux:
+
+```tmux
+bind-key -n 'C-h' if-shell "$is_vim" { send-keys C-h } { if-shell -F '#{pane_at_left}'   {} { select-pane -L } }
+bind-key -n 'C-j' if-shell "$is_vim" { send-keys C-j } { if-shell -F '#{pane_at_bottom}' {} { select-pane -D } }
+bind-key -n 'C-k' if-shell "$is_vim" { send-keys C-k } { if-shell -F '#{pane_at_top}'    {} { select-pane -U } }
+bind-key -n 'C-l' if-shell "$is_vim" { send-keys C-l } { if-shell -F '#{pane_at_right}'  {} { select-pane -R } }
+
+bind-key -T copy-mode-vi 'C-h' if-shell -F '#{pane_at_left}'   {} { select-pane -L }
+bind-key -T copy-mode-vi 'C-j' if-shell -F '#{pane_at_bottom}' {} { select-pane -D }
+bind-key -T copy-mode-vi 'C-k' if-shell -F '#{pane_at_top}'    {} { select-pane -U }
+bind-key -T copy-mode-vi 'C-l' if-shell -F '#{pane_at_right}'  {} { select-pane -R }
+```
+
+These bindings will prevent wrapping around to the opposite side when reaching
+the edge of the screen in tmux, matching the behavior when `no_wrap = true` is
+set in Neovim.
 
 #### Tmux Plugin Manager
 
@@ -129,7 +148,7 @@ just tell the plugin about it (inside the `setup` function):
 ```lua
 require'nvim-tmux-navigation'.setup {
     disable_when_zoomed = true, -- defaults to false
-    tmux_navigator_no_wrap = true -- defaults to false
+    no_wrap = true -- defaults to false
 }
 ```
 
@@ -143,7 +162,7 @@ inside your `init.lua`, you can do everything at once:
 
     nvim_tmux_nav.setup {
         disable_when_zoomed = true, -- defaults to false
-        tmux_navigator_no_wrap = true -- defaults to false
+        no_wrap = true -- defaults to false
     }
 
     vim.keymap.set('n', "<C-h>", nvim_tmux_nav.NvimTmuxNavigateLeft)
@@ -163,6 +182,7 @@ Or, for a shorter syntax:
 { 'alexghergh/nvim-tmux-navigation', config = function()
     require'nvim-tmux-navigation'.setup {
         disable_when_zoomed = true, -- defaults to false
+        no_wrap = true, -- defaults to false
         keybindings = {
             left = "<C-h>",
             down = "<C-j>",

--- a/lua/nvim-tmux-navigation/init.lua
+++ b/lua/nvim-tmux-navigation/init.lua
@@ -5,7 +5,7 @@ local M = {}
 -- default configuration, can be changed through the setup function
 local config = {
     disable_when_zoomed = false,
-    tmux_navigator_no_wrap = false,
+    no_wrap = false,
     keybindings = {}
 }
 
@@ -62,7 +62,7 @@ local function tmux_navigate(direction)
 
         -- if we're in the same window and zoom is not disabled, tmux should take control
         if util.should_tmux_control(is_same_winnr, config.disable_when_zoomed) then
-            util.tmux_change_pane(direction, config.tmux_navigator_no_wrap)
+            util.tmux_change_pane(direction, config.no_wrap)
             tmux_control = true
         else
             tmux_control = false
@@ -77,7 +77,7 @@ function M.setup(user_config)
 
     -- whether tmux should wrap around when navigating
     -- defaults to false
-    config.tmux_navigator_no_wrap = user_config.tmux_navigator_no_wrap or false
+    config.no_wrap = user_config.no_wrap or false
 
     -- keybindings for the navigation
     config.keybindings = user_config.keybindings or {}

--- a/lua/nvim-tmux-navigation/init.lua
+++ b/lua/nvim-tmux-navigation/init.lua
@@ -5,6 +5,7 @@ local M = {}
 -- default configuration, can be changed through the setup function
 local config = {
     disable_when_zoomed = false,
+    tmux_navigator_no_wrap = false,
     keybindings = {}
 }
 
@@ -61,7 +62,7 @@ local function tmux_navigate(direction)
 
         -- if we're in the same window and zoom is not disabled, tmux should take control
         if util.should_tmux_control(is_same_winnr, config.disable_when_zoomed) then
-            util.tmux_change_pane(direction)
+            util.tmux_change_pane(direction, config.tmux_navigator_no_wrap)
             tmux_control = true
         else
             tmux_control = false
@@ -73,6 +74,10 @@ function M.setup(user_config)
     -- disable nvim tmux navigation when a tmux pane is zoomed
     -- defaults to false
     config.disable_when_zoomed = user_config.disable_when_zoomed or false
+
+    -- whether tmux should wrap around when navigating
+    -- defaults to false
+    config.tmux_navigator_no_wrap = user_config.tmux_navigator_no_wrap or false
 
     -- keybindings for the navigation
     config.keybindings = user_config.keybindings or {}

--- a/lua/nvim-tmux-navigation/tmux_util.lua
+++ b/lua/nvim-tmux-navigation/tmux_util.lua
@@ -1,6 +1,7 @@
 local util = {}
 
 local tmux_directions = { ['p'] = 'l', ['h'] = 'L', ['j'] = 'D', ['k'] = 'U', ['l'] = 'R', ['n'] = 't:.+' }
+local tmux_pane = { ['h'] = 'pane_at_right', ['j'] = 'pane_at_top', ['k'] = 'pane_at_bottom', ['l'] = 'pane_at_left' }
 
 -- send the tmux command to the server running on the socket
 -- given by the environment variable $TMUX
@@ -27,8 +28,13 @@ function util.should_tmux_control(is_same_winnr, disable_nav_when_zoomed)
 end
 
 -- change the current pane according to direction
-function util.tmux_change_pane(direction)
-    tmux_command("select-pane -" .. tmux_directions[direction])
+function util.tmux_change_pane(direction, no_wrap)
+    -- if no_wrap is true and the direction is not "p" or "n"
+    if no_wrap and direction ~= 'p' and direction ~= 'n' then
+        tmux_command("if-shell -F \"#{" .. tmux_pane[direction] .. "}\" \"\"" .. "\"select-pane -" .. tmux_directions[direction] .. "\"")
+    else
+        tmux_command("select-pane -" .. tmux_directions[direction])
+    end
 end
 
 -- capitalization util, only capitalizes the first character of the whole word


### PR DESCRIPTION
- Introduce `tmux_navigator_no_wrap` config to prevent wrapping at pane edges
- Modify `tmux_change_pane` to respect the new no-wrap configuration
- Update default configuration and setup function to include no-wrap option

Implementing Disabling wrapping as intended in [christoomey/vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) and described in [Disable Wrapping](https://github.com/christoomey/vim-tmux-navigator?tab=readme-ov-file#disable-wrapping).