### PR TITLE
optimization: Speed up pane switching by circumventing shell and tmux CLI when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ more:
    possible workaround using `pgrep` (this might fail to work in some cases
    though; if you do find such a case please open an issue).
 
+   If you are still having performance problems when switching panes inside of
+   Neovim, consider setting `disable_when_zoomed = false` in the configuration
+   for this plugin. When enabled, this config option causes
+   `nvim-tmux-navigation` to invoke the `tmux` CLI every time you switch panes;
+   disabling this switch circumvents this system call and makes switching panes
+   much faster!
+
 3. Q: The plugin doesn't work when interacting with
    [Poetry](https://python-poetry.org/) shells.
    A: This happens because Poetry spawns sub-tty's, therefore messing with

--- a/lua/nvim-tmux-navigation/tmux_util.lua
+++ b/lua/nvim-tmux-navigation/tmux_util.lua
@@ -32,7 +32,7 @@ end
 
 -- whether tmux should take control over the navigation
 function util.should_tmux_control(is_same_winnr, disable_nav_when_zoomed)
-    if is_tmux_pane_zoomed() and disable_nav_when_zoomed then
+    if disable_nav_when_zoomed and is_tmux_pane_zoomed() then
         return false
     end
     return is_same_winnr


### PR DESCRIPTION
1. Motivation for circumventing Shell: Shell startup time is significant. For some reason, as @isaksamsten mentioned on #16, switching is significantly slower in Fish shell than in other shells. I did some experimentation and found that `vim.fn.system(<string>)` is slow when the `shell` option is set to Fish. This change removes dependence on the shell entirely when switching tmux panes, since `system` doesn't use a shell when a table is provided in place of a string.
2. Motivation for short circuiting zoom check: This lets us cut out the latency from invoking `tmux` at all, when a faster boolean check would rule out the conditional
