### PR TITLE
Fix bug where vim doesn't send enough information to switch to tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ more:
    possible workaround using `pgrep` (this might fail to work in some cases
    though; if you do find such a case please open an issue).
 
+   If you are still having performance problems when switching panes inside of
+   Neovim, consider setting `disable_when_zoomed = false` in the configuration
+   for this plugin. When enabled, this config option causes
+   `nvim-tmux-navigation` to invoke the `tmux` CLI every time you switch panes;
+   disabling this switch circumvents this system call and makes switching panes
+   much faster!
+
 3. Q: The plugin doesn't work when interacting with
    [Poetry](https://python-poetry.org/) shells.
    A: This happens because Poetry spawns sub-tty's, therefore messing with

--- a/lua/nvim-tmux-navigation/tmux_util.lua
+++ b/lua/nvim-tmux-navigation/tmux_util.lua
@@ -7,15 +7,35 @@ local tmux_directions = { ['p'] = 'l', ['h'] = 'L', ['j'] = 'D', ['k'] = 'U', ['
 --
 -- the check if tmux is actually running (so the variable $TMUX is
 -- not nil) is made before actually calling this function
-local function tmux_command(command)
+local function tmux_command(args)
     local tmux_socket = vim.fn.split(vim.env.TMUX, ',')[1]
-    return vim.fn.system("tmux -S " .. tmux_socket .. " " .. command)
+    local command = {
+      "tmux",
+      "-S",
+      tmux_socket,
+    };
+
+    -- Concat args into command
+    for _, v in ipairs(args) do
+        table.insert(command, v)
+    end
+
+    return vim.fn.system(command)
 end
 
 -- check whether the current tmux pane is zoomed
 local function is_tmux_pane_zoomed()
-    -- the output of the tmux command is "1\n", so we have to test against that
-    return tmux_command("display-message -p '#{window_zoomed_flag}'") == "1\n"
+    local zoomed_value = tmux_command({
+        "display-message",
+        "-p",
+        "#{window_zoomed_flag}",
+    }):gsub("%s+", "") -- the output of the tmux command is "1\n", so we strip that away
+
+    if zoomed_value == "1" then
+      return true
+    end
+
+    return false
 end
 
 -- whether tmux should take control over the navigation
@@ -28,7 +48,14 @@ end
 
 -- change the current pane according to direction
 function util.tmux_change_pane(direction)
-    tmux_command("select-pane -" .. tmux_directions[direction])
+    local pane_id = vim.env.TMUX_PANE;
+
+    tmux_command({
+        "select-pane",
+        "-t",
+        pane_id,
+        "-" .. tmux_directions[direction],
+    })
 end
 
 -- capitalization util, only capitalizes the first character of the whole word

--- a/lua/nvim-tmux-navigation/tmux_util.lua
+++ b/lua/nvim-tmux-navigation/tmux_util.lua
@@ -52,7 +52,7 @@ end
 
 -- whether tmux should take control over the navigation
 function util.should_tmux_control(is_same_winnr, disable_nav_when_zoomed)
-    if is_tmux_pane_zoomed() and disable_nav_when_zoomed then
+    if disable_nav_when_zoomed and is_tmux_pane_zoomed() then
         return false
     end
     return is_same_winnr


### PR DESCRIPTION
## Description

I've been having this issue for a while with `nvim-tmux-navigator` switching from tmux -> vim and vim -> vim fine, but wouldn't go vim -> tmux.

- This PR adds the pane_id info to the tmux command ([like vim-tmux-navigator does](https://github.com/christoomey/vim-tmux-navigator/blob/master/plugin/tmux_navigator.vim#L133))
- Uses the more structured arguments for `vim.fn.system`

Both of those were necessary to get it to work on my system.

## System info
- Pop!_OS `22.04`
- tmux `3.5a`
- tmux and nvim installed through Nix package manager